### PR TITLE
feat: package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .vercel
+
+package

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of [React Custom Hooks](https://reactjs.org/docs/hooks-custom.html)
 - (Optional) ⭐️ This repository
 - Create a new hook in `src/hooks` folder.
 - Show example usage in `src/App.tsx`.
-- If you don't know TypeScript, simply use `any` type or predefined [`DefinitelyNotAny`](./src/vite-env.d.ts) type
+- If you don't know TypeScript, simply use `any` type or import `DefinitelyNotAny` from "./types"
 - Try not to update other places or auto-format, it'll cause merge conflicts.
 
 ## TODOs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "package": "tsc -p tsconfig.package.json && cp package.json package"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,1 @@
+export type DefinitelyNotAny = any

--- a/src/hooks/useAny.ts
+++ b/src/hooks/useAny.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useAny(value: DefinitelyNotAny): DefinitelyNotAny {
   const result = useMemo(() => value as DefinitelyNotAny, [])

--- a/src/hooks/useCuteAndFunny.ts
+++ b/src/hooks/useCuteAndFunny.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useCuteAndFunny(...args: DefinitelyNotAny[]) {
   const result = useMemo(() => "😭", [])

--- a/src/hooks/useLess.ts
+++ b/src/hooks/useLess.ts
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useLess(initialValue: DefinitelyNotAny) {
   const [value, _setValue] = useState(initialValue)

--- a/src/hooks/useSmile.ts
+++ b/src/hooks/useSmile.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useSmile(...args: DefinitelyNotAny[]) {
   const result = useMemo(() => "😊", [])

--- a/src/hooks/useSus.ts
+++ b/src/hooks/useSus.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useSus(...args: DefinitelyNotAny[]) {
   const result = useMemo(() => "ඞ", [])

--- a/src/hooks/useVoid.ts
+++ b/src/hooks/useVoid.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from "react"
+import { DefinitelyNotAny } from "./types"
 
 export function useVoid(...args: DefinitelyNotAny[]) {
   useLayoutEffect(() => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,1 @@
 /// <reference types="vite/client" />
-
-type DefinitelyNotAny = any

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -6,5 +6,5 @@
     "noEmit": false,
     "declaration": true
   },
-  "include": ["./src/hooks/**/*", "src/vite-env.d.ts"]
+  "include": ["./src/hooks/**/*"]
 }

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/hooks",
+    "outDir": "./package",
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["./src/hooks/**/*", "src/vite-env.d.ts"]
+}


### PR DESCRIPTION
## How this works

- Run ~~pnpm~~ npm package
- cd to package and publish there

## To (you) do
- How to handle version number

## Usage

```tsx
import "./App.css";

import { useSalim } from "react-useless/useSalim";

function App() {
  const { quote, refetch } = useSalim();

  return (
    <div className="App">
      <p>{quote}</p>
      <button onClick={() => refetch()}>refetch</button>
    </div>
  );
}

export default App;
```

Note that no index import because I have not added it yet (If you want, feel free to tell me)

## Breaking Changes
`DefinitelyNotAny` now requires import due to limitation of being npm package

```ts
import { useMemo } from "react"
import { DefinitelyNotAny } from "./types"

export function useAny(value: DefinitelyNotAny): DefinitelyNotAny {
  const result = useMemo(() => value as DefinitelyNotAny, [])

  return result
}
```

On the bright side, it emphasize that it is DefinitelyNotAny