### PR TITLE
Extract components and use Vite meta glob import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of [React Custom Hooks](https://reactjs.org/docs/hooks-custom.html)
 
 - (Optional) ⭐️ This repository
 - Create a new hook in `src/hooks` folder.
-- Show example usage in `src/App.tsx`.
+- ~~Show example usage in `src/App.tsx`.~~ Don't touch anything in `App.tsx`. Create a component that use the hook in `src/hooks-usage` folder, use [the component template](./src/hooks-usage/_TEMPLATE.tsx).
 - If you don't know TypeScript, simply use `any` type or import `DefinitelyNotAny` from "./types"
 - Try not to update other places or auto-format, it'll cause merge conflicts.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "package": "tsc -p tsconfig.package.json && cp package.json package"
+    "package": "tsc -p tsconfig.package.json && cp package.json package",
+    "prepare": "husky install"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
-import { FallbackProps, withErrorBoundary } from "react-error-boundary";
+import { Fragment } from "react"
+import { FallbackProps, withErrorBoundary } from "react-error-boundary"
 
 import reactLogo from "./assets/react.svg"
 import "./App.css"
 
 import Card, { CardProps } from "./components/Card"
-import { useException } from './hooks/useException';
+
+// Load all components from src/hooks-usage
+const allHooksUsage = import.meta.glob("./hooks-usage/*.tsx", { eager: true })
+
+import { useException } from "./hooks/useException"
 import { useLess } from "./hooks/useLess"
 import { useEven } from "./hooks/useEven"
 import { useCuteAndFunny } from "./hooks/useCuteAndFunny"
@@ -58,14 +63,14 @@ const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   )
 }
 
-
-const UseExceptionExampleComponent = withErrorBoundary(() => {
-  const throwException = useException();
-  throwException('Bad Request', (new Date()).toString());
-  return <></>;
-}, { FallbackComponent: ErrorFallback });
-
-
+const UseExceptionExampleComponent = withErrorBoundary(
+  () => {
+    const throwException = useException()
+    throwException("Bad Request", new Date().toString())
+    return <></>
+  },
+  { FallbackComponent: ErrorFallback }
+)
 
 const UseSalimExampleComponent = () => {
   const { quote: salimQuote, refetch: salimRefetch } = useSalim()
@@ -81,17 +86,17 @@ const UseSalimExampleComponent = () => {
 
 function App() {
   const hooks: CardProps[] = [
-    {
-      desc: "useLess - a useless hook that returns initial value.",
-      examples: [
-        { code: "const value = useLess(0)", value: useLess(0) },
-        {
-          code: 'const anotherValue = useLess("ඞ")',
-          value: useLess("ඞ"),
-        },
-      ],
-      githubUsername: "narze",
-    },
+    // {
+    //   desc: "useLess - a useless hook that returns initial value.",
+    //   examples: [
+    //     { code: "const value = useLess(0)", value: useLess(0) },
+    //     {
+    //       code: 'const anotherValue = useLess("ඞ")',
+    //       value: useLess("ඞ"),
+    //     },
+    //   ],
+    //   githubUsername: "narze",
+    // },
     {
       desc: "useEven - a useful hook to check number is even or not.",
       examples: [
@@ -355,12 +360,13 @@ function App() {
         },
       ],
       githubUsername: "ronnapatp",
-    }, {
+    },
+    {
       desc: "useException - throw an exception with arguments",
       examples: [
         {
           code: `const throwException = useException()`,
-          value: <UseExceptionExampleComponent/>,
+          value: <UseExceptionExampleComponent />,
         },
       ],
       githubUsername: "tomerk97",
@@ -376,12 +382,12 @@ function App() {
       githubUsername: "armsasmart",
     },
     {
-      desc: 'useDontKnow - We don\'t know anything in this universe !!',
+      desc: "useDontKnow - We don't know anything in this universe !!",
       examples: [
         {
           code: `const message = useDontKnow()`,
-          value: `Do you know about flooding situation ? ${useDontKnow()}`
-        }
+          value: `Do you know about flooding situation ? ${useDontKnow()}`,
+        },
       ],
       githubUsername: "sikkapat79",
     },
@@ -390,8 +396,16 @@ function App() {
       examples: [
         {
           code: `useFreeze(() => console.log('Hello Antarctica'))`,
-          value: <button onClick={() => { useFreeze(() => "Sike") }}>I kid you not</button>
-        }
+          value: (
+            <button
+              onClick={() => {
+                useFreeze(() => "Sike")
+              }}
+            >
+              I kid you not
+            </button>
+          ),
+        },
       ],
       githubUsername: "pknn",
     },
@@ -426,6 +440,13 @@ function App() {
   ] // Add your own hooks usage above this comment (at the end of the list)
   // Create a new component if your hook needs more customization
 
+  const hooksUsageComponents = Object.entries(allHooksUsage).map(
+    ([_path, module]) => {
+      const component = (module as any).default
+      return component as () => JSX.Element
+    }
+  )
+
   return (
     <div className="App">
       <div>
@@ -436,8 +457,16 @@ function App() {
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
+
       <h1>React Useless Hooks</h1>
       <h2>({hooks.length} hooks)</h2>
+
+      {/* New hooks usage components automatically loaded from src/hooks-usage */}
+      {hooksUsageComponents.map((element, idx) => {
+        return <Fragment key={idx}>{element()}</Fragment>
+      })}
+
+      {/* Legacy hooks from "hooks" array */}
       {hooks.map((props: CardProps, idx) => {
         return <Card key={idx} {...props} />
       })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -440,8 +440,7 @@ function App() {
       ],
       githubUsername: "ntsd",
     },
-  ] // Add your own hooks usage above this comment (at the end of the list)
-  // Create a new component if your hook needs more customization
+  ] // DON'T ADD ANY CODE HERE. ALL THESE HOOKS WILL BE MIGRATED TO src/hooks-usage SOON
 
   const hooksUsageComponents = Object.entries(allHooksUsage).map(
     ([_path, module]) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,10 @@ import "./App.css"
 import Card, { CardProps } from "./components/Card"
 
 // Load all components from src/hooks-usage
-const allHooksUsage = import.meta.glob("./hooks-usage/*.tsx", { eager: true })
+const allHooksUsage = import.meta.glob(
+  ["./hooks-usage/*.tsx", "!./hooks-usage/_TEMPLATE.tsx"],
+  { eager: true }
+)
 
 import { useException } from "./hooks/useException"
 import { useLess } from "./hooks/useLess"

--- a/src/hooks-usage/_TEMPLATE.tsx
+++ b/src/hooks-usage/_TEMPLATE.tsx
@@ -1,21 +1,33 @@
 // This file is a template, save this file as <yourHookName>.tsx and remove this comment
 
 import Card from "../components/Card"
+
 import { useLess } from "../hooks/useLess"
+import { useSalim } from "../hooks/useSalim"
 
 // Default export a functional component which includes hook's usage
 // You can use our Card component or roll your own container component
 export default function () {
   const cardProps = {
-    desc: "useLess - a useless hook that returns initial value.",
+    desc: "useYourHookName - returns something yada yada yada",
     examples: [
+      // For simple form, just pass the hook's return value
       { code: "const value = useLess(0)", value: useLess(0) },
-      {
-        code: 'const anotherValue = useLess("ඞ")',
-        value: useLess("ඞ"),
+
+      // Or, use function component form for more complex example with buttons
+      () => {
+        const { quote: salimQuote, refetch: salimRefetch } = useSalim()
+
+        return (
+          <>
+            <code>const {"{ quote, refetch }"} = useSalim()</code>
+            <div>quote is {salimQuote}</div>
+            <button onClick={() => salimRefetch()}>Click to refetch</button>
+          </>
+        )
       },
     ],
-    githubUsername: "narze",
+    githubUsername: "yourGithubUsername",
   }
 
   return <Card {...cardProps} />

--- a/src/hooks-usage/_TEMPLATE.tsx
+++ b/src/hooks-usage/_TEMPLATE.tsx
@@ -1,0 +1,22 @@
+// This file is a template, save this file as <yourHookName>.tsx and remove this comment
+
+import Card from "../components/Card"
+import { useLess } from "../hooks/useLess"
+
+// Default export a functional component which includes hook's usage
+// You can use our Card component or roll your own container component
+export default function () {
+  const cardProps = {
+    desc: "useLess - a useless hook that returns initial value.",
+    examples: [
+      { code: "const value = useLess(0)", value: useLess(0) },
+      {
+        code: 'const anotherValue = useLess("ඞ")',
+        value: useLess("ඞ"),
+      },
+    ],
+    githubUsername: "narze",
+  }
+
+  return <Card {...cardProps} />
+}

--- a/src/hooks-usage/useLess.tsx
+++ b/src/hooks-usage/useLess.tsx
@@ -1,0 +1,18 @@
+import Card from "../components/Card"
+import { useLess } from "../hooks/useLess"
+
+export default function () {
+  const cardProps = {
+    desc: "useLess - a useless hook that returns initial value.",
+    examples: [
+      { code: "const value = useLess(0)", value: useLess(0) },
+      {
+        code: 'const anotherValue = useLess("ඞ")',
+        value: useLess("ඞ"),
+      },
+    ],
+    githubUsername: "narze",
+  }
+
+  return <Card {...cardProps} />
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Fixes #11 

Utilize Vite's [Glob Import](https://vitejs.dev/guide/features.html#glob-import) so that `App.tsx` can be left alone, causing less PR conflicts

Update readme to direct contributers to create a new component with hook usage in `src/hooks-usage` instead

Provide template file for creating hook usage component https://github.com/narze/react-useless/pull/58/files#diff-4ac7e44041195c7a7bbefd7d26dde13d8e8d6f4f010f49b5626c6ae7bd7a1bdf
