### PR TITLE
auto publish to npm

### DIFF
--- a/.github/PUBLISH.yml
+++ b/.github/PUBLISH.yml
@@ -1,0 +1,17 @@
+name: Publish Package to npm
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
fixed #62 , requires .npmrc & NPM_TOKEN github secret to work.