### PR TITLE
Render each hook usage as a page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import "./App.css"
 import HooksLayout from "./HooksLayout"
 import AllHooksPage from "./pages/AllHooksPage"
 import HomePage from "./pages/HomePage"
+import HookPage from "./pages/HookPage"
 
 function App() {
   const defaultDark = window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -60,6 +61,7 @@ function App() {
           <Route index element={<HomePage />}></Route>
           <Route path="hooks" element={<HooksLayout />}>
             <Route index element={<AllHooksPage />}></Route>
+            <Route path=":hookName" element={<HookPage />}></Route>
           </Route>
         </Routes>
       </div>

--- a/src/HooksLayout.tsx
+++ b/src/HooksLayout.tsx
@@ -37,7 +37,7 @@ function HooksLayout() {
       </div>
       <div className="drawer-side">
         <label htmlFor="app-drawer" className="drawer-overlay"></label>
-        <ul className="menu p-4 overflow-y-auto w-80 text-base-content bg-[#1a1a1a]">
+        <ul className="menu flex-nowrap p-4 overflow-y-auto w-80 text-base-content bg-[#1a1a1a]">
           <AppNavLogo />
           {renderRouteSidebarItems}
         </ul>

--- a/src/hooks-usage/index.ts
+++ b/src/hooks-usage/index.ts
@@ -1,0 +1,14 @@
+import type React from "react"
+
+const modules = import.meta.glob(
+  ["./*.tsx", "!./_TEMPLATE.tsx", "!./index.tsx"],
+  { eager: true }
+)
+
+export const allHooksUsage: Record<string, React.ComponentType> = {}
+
+Object.entries(modules).forEach(([path, module]) => {
+  const name = path.match(/^.\/(.+).tsx$/)![1]
+  const component = (module as any).default as React.ComponentType
+  allHooksUsage[name] = component
+})

--- a/src/pages/AllHooksPage.tsx
+++ b/src/pages/AllHooksPage.tsx
@@ -1,19 +1,9 @@
 import { Fragment } from "react"
 import reactLogo from "../assets/react.svg"
-
-// Load all components from src/hooks-usage
-const allHooksUsage = import.meta.glob(
-  ["../hooks-usage/*.tsx", "!../hooks-usage/_TEMPLATE.tsx"],
-  { eager: true }
-)
+import { allHooksUsage } from "../hooks-usage"
 
 function App() {
-  const hooksUsageComponents = Object.entries(allHooksUsage).map(
-    ([_path, module]) => {
-      const component = (module as any).default
-      return component as () => JSX.Element
-    }
-  )
+  const entries = Object.entries(allHooksUsage)
 
   return (
     <div className="App">
@@ -25,12 +15,12 @@ function App() {
 
       <h1 className="text-center">React Useless Hooks</h1>
       <p className="text-center">
-        We have {hooksUsageComponents.length} useless hooks, and counting...
+        We have {entries.length} useless hooks, and counting...
       </p>
 
       {/* New hooks usage components automatically loaded from src/hooks-usage */}
-      {hooksUsageComponents.map((element, idx) => {
-        return <Fragment key={idx}>{element()}</Fragment>
+      {entries.map(([name, Component]) => {
+        return <Component key={name} />
       })}
 
       <div className="card">

--- a/src/pages/HookPage.tsx
+++ b/src/pages/HookPage.tsx
@@ -1,0 +1,23 @@
+import { Fragment } from "react"
+import { useParams } from "react-router-dom"
+import reactLogo from "../assets/react.svg"
+import { allHooksUsage } from "../hooks-usage"
+import { useException } from "../hooks/useException"
+
+function HookPage() {
+  const { hookName } = useParams()
+  const Component = allHooksUsage[hookName ?? ""]
+  const throwException = useException()
+  if (!Component) {
+    throwException(`Hook ${hookName} not found`)
+  }
+
+  return (
+    <div className="App">
+      <h1 className="text-center">{hookName}</h1>
+      <Component />
+    </div>
+  )
+}
+
+export default HookPage

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from "react-router-dom"
+import { allHooksUsage } from "./hooks-usage"
 
 export const renderRouteSidebarItems = (
   <>
@@ -11,17 +12,17 @@ export const renderRouteSidebarItems = (
         All hooks
       </NavLink>
     </li>
-    {/* {Object.keys(hookRoutes).map((hookName) => (
-      <li key={hookName}>
+    {Object.entries(allHooksUsage).map(([name, Component]) => (
+      <li key={name}>
         <NavLink
-          to={hookName}
+          to={`/hooks/${name}`}
           className={({ isActive }) =>
             `hover:text-white ${isActive && "active"}`
           }
         >
-          {hookName}
+          {name}
         </NavLink>
       </li>
-    ))} */}
+    ))}
   </>
 )


### PR DESCRIPTION
This PR adds a dynamic route `/hook/:hookName` that points to individual hooks.
Links to each page are also added to the sidebar for navigation.

Implements #96.

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/8080853/194079863-131d226a-7853-4727-9edb-eef5b0aa41e0.png">
