### PR TITLE
👔 fix hooks ordering

### DIFF
--- a/src/hooks-usage/index.ts
+++ b/src/hooks-usage/index.ts
@@ -5,10 +5,29 @@ const modules = import.meta.glob(
   { eager: true }
 )
 
-export const allHooksUsage: Record<string, React.ComponentType> = {}
+export type Hook = {
+  name: string
+  Component: React.ComponentType
+}
 
-Object.entries(modules).forEach(([path, module]) => {
-  const name = path.match(/^.\/(.+).tsx$/)![1]
-  const component = (module as any).default as React.ComponentType
-  allHooksUsage[name] = component
-})
+export const allHooksUsage: Hook[] = Object.entries(modules)
+  .map(([path, module]) => {
+    const name = path.match(/^.\/(.+).tsx$/)![1]
+    const component = (module as any).default as React.ComponentType
+    return { name, Component: component } as Hook
+  })
+  .sort((hook, anotherHook) => {
+    if (hook.name === "useLess" || anotherHook.name === "paUse") {
+      return -1
+    }
+    if (anotherHook.name === "useLess" || hook.name === "paUse") {
+      return 1
+    }
+    if (hook.name > anotherHook.name) {
+      return 1
+    }
+    if (hook.name < anotherHook.name) {
+      return -1
+    }
+    return 0
+  })

--- a/src/pages/AllHooksPage.tsx
+++ b/src/pages/AllHooksPage.tsx
@@ -1,10 +1,8 @@
 import { Fragment } from "react"
 import reactLogo from "../assets/react.svg"
-import { allHooksUsage } from "../hooks-usage"
+import { allHooksUsage, Hook } from "../hooks-usage"
 
 function App() {
-  const entries = Object.entries(allHooksUsage)
-
   return (
     <div className="App">
       <div className="flex justify-center gap-4">
@@ -15,12 +13,12 @@ function App() {
 
       <h1 className="text-center">React Useless Hooks</h1>
       <p className="text-center">
-        We have {entries.length} useless hooks, and counting...
+        We have {allHooksUsage.length} useless hooks, and counting...
       </p>
 
       {/* New hooks usage components automatically loaded from src/hooks-usage */}
-      {entries.map(([name, Component]) => {
-        return <Component key={name} />
+      {allHooksUsage.map((hook: Hook) => {
+        return <hook.Component key={hook.name} />
       })}
 
       <div className="card">

--- a/src/pages/HookPage.tsx
+++ b/src/pages/HookPage.tsx
@@ -1,16 +1,16 @@
 import { Fragment } from "react"
 import { useParams } from "react-router-dom"
-import reactLogo from "../assets/react.svg"
 import { allHooksUsage } from "../hooks-usage"
 import { useException } from "../hooks/useException"
 
 function HookPage() {
   const { hookName } = useParams()
-  const Component = allHooksUsage[hookName ?? ""]
+  const hookWithName = allHooksUsage.filter((hook) => hook.name === hookName)
   const throwException = useException()
-  if (!Component) {
+  if (hookWithName.length === 0) {
     throwException(`Hook ${hookName} not found`)
   }
+  const Component = hookWithName[0].Component
 
   return (
     <div className="App">

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom"
-import { allHooksUsage } from "./hooks-usage"
+import { allHooksUsage, Hook } from "./hooks-usage"
 
 export const renderRouteSidebarItems = (
   <>
@@ -12,15 +12,15 @@ export const renderRouteSidebarItems = (
         All hooks
       </NavLink>
     </li>
-    {Object.entries(allHooksUsage).map(([name, Component]) => (
-      <li key={name}>
+    {allHooksUsage.map((hook: Hook) => (
+      <li key={hook.name}>
         <NavLink
-          to={`/hooks/${name}`}
+          to={`/hooks/${hook.name}`}
           className={({ isActive }) =>
             `hover:text-white ${isActive && "active"}`
           }
         >
-          {name}
+          {hook.name}
         </NavLink>
       </li>
     ))}


### PR DESCRIPTION
### Description
Fix hooks ordering as mentioned in #106.

- Fix `useLess` at the top of the page and the list.
- Fix `paUse` at the bottom of the list.
- Sort other hooks order alphabetically

### Screen record

<img width="1592" alt="Screenshot 2565-10-06 at 14 02 43" src="https://user-images.githubusercontent.com/16893636/194236174-4eed44e3-b23e-4536-9dce-1f2c791b1603.png">

<img width="1449" alt="Screenshot 2565-10-06 at 14 02 52" src="https://user-images.githubusercontent.com/16893636/194236092-112c4bb5-abfb-45a9-a799-36793e73aaea.png">